### PR TITLE
Fix log message that identified the wrong function.

### DIFF
--- a/lib/highwaterService.js
+++ b/lib/highwaterService.js
@@ -52,7 +52,7 @@ function createServer(serverConfig, metricsConfig, userApiClient) {
     if (req._tokendata != null && !req._tokendata.isserver) {
       return next();
     }
-    log.error('requireServerToken failed. uid=%s isserver=%s', req._tokendata.userid, req._tokendata.isserver);
+    log.error('requireUserToken failed. uid=%s isserver=%s', req._tokendata.userid, req._tokendata.isserver);
     res.send(401, 'Insufficient Permissions');
     return next(false);
   }


### PR DESCRIPTION
This is a change that only affects the text of a misleading log function; no functionality change. 
