### PR TITLE
Enable traces for warnings to track down a memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "./lib"
   },
   "scripts": {
-    "start": "node lib/index.js",
+    "start": "node --trace-warnings lib/index.js",
     "test": "mocha"
   },
   "repository": "https://github.com/tidepool-org/highwater.git",

--- a/start.sh
+++ b/start.sh
@@ -8,4 +8,4 @@ nvm use --delete-prefix "${START_NODE_VERSION}"
 
 . config/env.sh
 
-exec node lib/index.js
+exec node --trace-warnings lib/index.js


### PR DESCRIPTION
There a potential memory leak described in [BACK-1220](https://tidepool.atlassian.net/browse/BACK-1220), but only an obscure warning is being logged without any context. This change enables stack traces for warnings.