### PR TITLE
[BACK-1220] Handle potentially unhandled exceptions in uncaught exception handler

### DIFF
--- a/lib/highwaterService.js
+++ b/lib/highwaterService.js
@@ -94,7 +94,11 @@ function createServer(serverConfig, highwaterApi, userApiClient) {
 
   retVal.on('uncaughtException', function(req, res, route, err){
     log.error(err, 'Uncaught exception on route[%s]!', route.spec ? route.spec.path : 'unknown');
-    res.send(500);
+    try {
+      res.send(500);
+    } catch(e) {
+      // ignore exceptions
+    }
   });
 
   return retVal;


### PR DESCRIPTION
If the unhandled exception is caused by a networking issue, there's no way to respond to the request. This might be causing a memory leak.