### PR TITLE
[BACK-2699] Update amoeba to allow disabling acks for the event producer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "amoeba": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/amoeba/-/amoeba-1.0.2.tgz",
-      "integrity": "sha512-YnMBSOjalqgdOkh1DKb4bclokmGLvWavERDgnBo6TBicmHEWzAtp+4iHWH7/2ljtK0XNnQM3TqSt30/zIMy85w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/amoeba/-/amoeba-1.1.0.tgz",
+      "integrity": "sha512-lUDac49gVmsfZ0i5vbTx2SddCrMj8mKpRgj995N6s4ikIMC0RrXqDs/D6ZaYVL8f3TWg2wlp6Mr1/YI75UPZZg==",
       "requires": {
         "bunyan": "1.8.12",
         "kafkajs": "^1.14.0",
@@ -55,7 +55,7 @@
         "bunyan": {
           "version": "1.8.12",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-          "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+          "integrity": "sha512-dmDUbGHeGcvCDLRFOscZkwx1ZO/aFz3bJOCi5nCgzdhFGPxwK+y5AcDBnqagNGlJZ7lje/l6JUEz9mQcutttdg==",
           "requires": {
             "dtrace-provider": "~0.8",
             "moment": "^2.10.6",
@@ -112,9 +112,9 @@
           }
         },
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "@godaddy/terminus": "^4.6.0",
-    "amoeba": "^1.0.2",
+    "amoeba": "^1.1.0",
     "aws-sdk": "2.1.23",
     "bunyan": "1.8.14",
     "crypto-js": "3.1.2-5",


### PR DESCRIPTION
Acks are now disabled by default in the helm chart https://github.com/tidepool-org/development/pull/253